### PR TITLE
fix: swap order of PG_diff check and deleteOutputDir()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed edge case where certain corrupt NIFs cause hangs and memory leaks
 - Game location, type, and selected profile will be set automatically when MO2 is configured now
 - Added extra data option for MAs to tell PG to ignore patching a shape (see wiki)
+- Fixed output exist check happening after existing output deleting
 
 ## [0.8.12] - 2025-05-18
 

--- a/PGPatcher/src/main.cpp
+++ b/PGPatcher/src/main.cpp
@@ -294,15 +294,15 @@ void mainRunner(ParallaxGenCLIArgs& args, const filesystem::path& exePath)
         mmd.populateModFileMapVortex(bg.getGameDataPath());
     }
 
-    // delete existing output
-    ParallaxGen::deleteOutputDir();
-
     // Check if ParallaxGen output already exists in data directory
     const filesystem::path pgStateFilePath = bg.getGameDataPath() / "ParallaxGen_Diff.json";
     if (filesystem::exists(pgStateFilePath)) {
         Logger::critical("ParallaxGen meshes exist in your data directory, please delete before "
                          "re-running.");
     }
+
+    // delete existing output
+    ParallaxGen::deleteOutputDir();
 
     // Init file map
     pgd.populateFileMap(params.Processing.bsa);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the order of output existence checks and deletion to prevent potential issues when handling output files.

* **Documentation**
  * Updated the changelog to reflect the fix related to output existence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->