### PR TITLE
feat: patch light placer jsons with duplicate NIFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added extra data option for MAs to tell PG to ignore patching a shape (see wiki)
 - Fixed output exist check happening after existing output deleting
 - If MO2 is selected and not launched from MO2 a critical error will not be shown
+- Light placer JSONs will now be patched if PG created a duplicate NIF
 
 ## [0.8.12] - 2025-05-18
 

--- a/PGLib/include/PGGlobals.hpp
+++ b/PGLib/include/PGGlobals.hpp
@@ -10,7 +10,8 @@ private:
     static ModManagerDirectory* s_MMD;
 
 public:
-    static inline std::unordered_set<std::filesystem::path> s_foldersToMap = { "meshes", "textures", "pbrnifpatcher" };
+    static inline std::unordered_set<std::filesystem::path> s_foldersToMap
+        = { "meshes", "textures", "pbrnifpatcher", "lightplacer" };
 
     static auto getPGD() -> ParallaxGenDirectory*;
     static void setPGD(ParallaxGenDirectory* pgd);

--- a/PGLib/include/ParallaxGenDirectory.hpp
+++ b/PGLib/include/ParallaxGenDirectory.hpp
@@ -53,6 +53,7 @@ private:
     std::unordered_map<std::filesystem::path, NifCache> m_meshes;
     std::unordered_set<std::filesystem::path> m_textures;
     std::vector<std::filesystem::path> m_pbrJSONs;
+    std::vector<std::filesystem::path> m_lightPlacerJSONs;
 
     // Mutexes
     std::shared_mutex m_textureMapsMutex;
@@ -128,6 +129,8 @@ public:
     [[nodiscard]] auto getTextures() const -> const std::unordered_set<std::filesystem::path>&;
 
     [[nodiscard]] auto getPBRJSONs() const -> const std::vector<std::filesystem::path>&;
+
+    [[nodiscard]] auto getLightPlacerJSONs() const -> const std::vector<std::filesystem::path>&;
 
     auto addTextureAttribute(const std::filesystem::path& path, const NIFUtil::TextureAttribute& attribute) -> bool;
 

--- a/PGLib/include/handlers/HandlerLightPlacerTracker.hpp
+++ b/PGLib/include/handlers/HandlerLightPlacerTracker.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <filesystem>
+#include <mutex>
+
+#include <nlohmann/json.hpp>
+
+class HandlerLightPlacerTracker {
+private:
+    struct LPJSON {
+        std::filesystem::path jsonPath;
+        std::mutex jsonMutex;
+        nlohmann::json jsonData;
+        bool changed = false;
+
+        LPJSON(std::filesystem::path path, nlohmann::json data = {})
+            : jsonPath(std::move(path))
+            , jsonData(std::move(data))
+        {
+        }
+    };
+
+    static std::vector<std::unique_ptr<LPJSON>> s_lightPlacerJSONs;
+    static std::unordered_map<std::filesystem::path, std::vector<std::pair<LPJSON*, nlohmann::json*>>>
+        s_lightPlacerJSONMap;
+
+public:
+    static void init(const std::vector<std::filesystem::path>& lpJSONs);
+
+    /**
+     * @brief Handles the creation of a NIF file and updates the associated light placer JSONs. THIS IS THE ONLY METHOD
+     * THAT IS THREAD SAFE
+     *
+     * @param baseNIFPath base NIF path
+     * @param createdNIFPath created NIF path (which may be the same)
+     */
+    static void handleNIFCreated(const std::filesystem::path& baseNIFPath, const std::filesystem::path& createdNIFPath);
+    static void finalize();
+};

--- a/PGLib/include/handlers/HandlerLightPlacerTracker.hpp
+++ b/PGLib/include/handlers/HandlerLightPlacerTracker.hpp
@@ -25,6 +25,11 @@ private:
         s_lightPlacerJSONMap;
 
 public:
+    /**
+     * @brief Initializes the light placer tracker with the provided JSON files. NOT THREAD SAFE
+     *
+     * @param lpJSONs A vector of paths to the light placer JSON files to be tracked.
+     */
     static void init(const std::vector<std::filesystem::path>& lpJSONs);
 
     /**
@@ -35,5 +40,9 @@ public:
      * @param createdNIFPath created NIF path (which may be the same)
      */
     static void handleNIFCreated(const std::filesystem::path& baseNIFPath, const std::filesystem::path& createdNIFPath);
+
+    /**
+     * @brief Finalizes the light placer tracker, releasing any resources and cleaning up. NOT THREAD SAFE
+     */
     static void finalize();
 };

--- a/PGLib/include/util/ParallaxGenUtil.hpp
+++ b/PGLib/include/util/ParallaxGenUtil.hpp
@@ -38,6 +38,8 @@ auto saveJSON(const std::filesystem::path& filePath, const nlohmann::json& json,
 
 auto checkIfStringInJSONArray(const nlohmann::json& json, const std::string& str) -> bool;
 
+auto getPluginPathFromDataPath(const std::filesystem::path& dataPath) -> std::filesystem::path;
+
 // Template Functions
 template <typename T> auto isInVector(const std::vector<T>& vec, const T& test) -> bool
 {

--- a/PGLib/include/util/ParallaxGenUtil.hpp
+++ b/PGLib/include/util/ParallaxGenUtil.hpp
@@ -38,6 +38,13 @@ auto saveJSON(const std::filesystem::path& filePath, const nlohmann::json& json,
 
 auto checkIfStringInJSONArray(const nlohmann::json& json, const std::string& str) -> bool;
 
+/**
+ * @brief Get the Plugin Path From Data Path object (removes textures or meshes from beginning of path)
+ *
+ * @param dataPath The data path to process
+ * @return std::filesystem::path The plugin path derived from the data path, or the original path if it does not start
+ * with "meshes" or "textures"
+ */
 auto getPluginPathFromDataPath(const std::filesystem::path& dataPath) -> std::filesystem::path;
 
 // Template Functions

--- a/PGLib/src/ParallaxGen.cpp
+++ b/PGLib/src/ParallaxGen.cpp
@@ -34,6 +34,7 @@
 #include "ParallaxGenRunner.hpp"
 #include "ParallaxGenTask.hpp"
 #include "ParallaxGenWarnings.hpp"
+#include "handlers/HandlerLightPlacerTracker.hpp"
 #include "patchers/PatcherTextureHookConvertToCM.hpp"
 #include "patchers/PatcherTextureHookFixSSS.hpp"
 #include "patchers/base/PatcherMeshShader.hpp"
@@ -63,6 +64,9 @@ void ParallaxGen::loadPatchers(
 void ParallaxGen::patch(const bool& multiThread, const bool& patchPlugin)
 {
     auto* const pgd = PGGlobals::getPGD();
+
+    // Init Handlers
+    HandlerLightPlacerTracker::init(pgd->getLightPlacerJSONs());
 
     //
     // MESH PATCHING
@@ -108,6 +112,9 @@ void ParallaxGen::patch(const bool& multiThread, const bool& patchPlugin)
 
     // Print any resulting warning
     ParallaxGenWarnings::printWarnings();
+
+    // Finalize handlers
+    HandlerLightPlacerTracker::finalize();
 }
 
 void ParallaxGen::populateModData(const bool& multiThread, const bool& patchPlugin)
@@ -404,6 +411,7 @@ auto ParallaxGen::patchNIF(const std::filesystem::path& nifPath, const bool& pat
 
         // tell PGD that this is a generated file
         pgd->addGeneratedFile(createdNIFFile, nullptr);
+        HandlerLightPlacerTracker::handleNIFCreated(nifPath, createdNIFFile);
 
         // assign mesh in plugins
         {

--- a/PGLib/src/ParallaxGenDirectory.cpp
+++ b/PGLib/src/ParallaxGenDirectory.cpp
@@ -85,6 +85,10 @@ auto ParallaxGenDirectory::findFiles() -> void
                 // Found PBR JSON config
                 spdlog::trace(L"Finding Files | Found PBR JSON | {}", path.wstring());
                 m_pbrJSONs.push_back(path);
+            } else if (boost::iequals(firstPath, L"lightplacer")) {
+                // Found Light Placer JSON config
+                spdlog::trace(L"Finding Files | Found Light Placer JSON | {}", path.wstring());
+                m_lightPlacerJSONs.push_back(path);
             }
         }
     }
@@ -477,6 +481,8 @@ auto ParallaxGenDirectory::getMeshes() const -> const unordered_map<filesystem::
 auto ParallaxGenDirectory::getTextures() const -> const unordered_set<filesystem::path>& { return m_textures; }
 
 auto ParallaxGenDirectory::getPBRJSONs() const -> const vector<filesystem::path>& { return m_pbrJSONs; }
+
+auto ParallaxGenDirectory::getLightPlacerJSONs() const -> const vector<filesystem::path>& { return m_lightPlacerJSONs; }
 
 auto ParallaxGenDirectory::addTextureAttribute(const filesystem::path& path, const NIFUtil::TextureAttribute& attribute)
     -> bool

--- a/PGLib/src/handlers/HandlerLightPlacerTracker.cpp
+++ b/PGLib/src/handlers/HandlerLightPlacerTracker.cpp
@@ -1,0 +1,115 @@
+#include "handlers/HandlerLightPlacerTracker.hpp"
+#include "PGGlobals.hpp"
+#include "util/ParallaxGenUtil.hpp"
+#include <boost/algorithm/string/predicate.hpp>
+#include <nlohmann/json_fwd.hpp>
+
+using namespace std;
+
+// statics
+vector<unique_ptr<HandlerLightPlacerTracker::LPJSON>> HandlerLightPlacerTracker::s_lightPlacerJSONs;
+unordered_map<filesystem::path, vector<pair<HandlerLightPlacerTracker::LPJSON*, nlohmann::json*>>>
+    HandlerLightPlacerTracker::s_lightPlacerJSONMap;
+
+void HandlerLightPlacerTracker::init(const vector<filesystem::path>& lpJSONs)
+{
+    static auto* const pgd = PGGlobals::getPGD();
+
+    // Clear and reserve space for new LPJSONs
+    s_lightPlacerJSONs.clear();
+    s_lightPlacerJSONs.reserve(lpJSONs.size());
+
+    for (const auto& jsonPath : lpJSONs) {
+        // Load JSON data
+        nlohmann::json jsonData;
+        if (!ParallaxGenUtil::getJSON(pgd->getLooseFileFullPath(jsonPath), jsonData)) {
+            // unable to load
+            continue;
+        }
+
+        // Add to s_lightPlacerJSONMutexMap
+        s_lightPlacerJSONs.emplace_back(make_unique<LPJSON>(jsonPath, std::move(jsonData)));
+        auto* const lpJsonPtr = s_lightPlacerJSONs.back().get();
+
+        // loop through json to create nif map
+        for (const auto& block : s_lightPlacerJSONs.back()->jsonData.items()) {
+            if (!block.value().is_object() || !block.value().contains("models")) {
+                continue; // skip if not a valid light placer block
+            }
+
+            auto& models = block.value()["models"];
+            if (!models.is_array()) {
+                continue; // skip if models is not an array
+            }
+
+            for (const auto& model : models) {
+                if (!model.is_string()) {
+                    continue; // skip if model is not a string
+                }
+
+                const filesystem::path modelPath = model.get<string>();
+                s_lightPlacerJSONMap[modelPath].emplace_back(lpJsonPtr, &models);
+            }
+        }
+    }
+}
+
+void HandlerLightPlacerTracker::handleNIFCreated(
+    const filesystem::path& baseNIFPath, const filesystem::path& createdNIFPath)
+{
+    if (baseNIFPath == createdNIFPath) {
+        // Not a duplicate nif, no reason to continue
+        return;
+    }
+
+    // Remove "meshes" from from the first part of both paths
+    const auto baseNIFPathLP = ParallaxGenUtil::getPluginPathFromDataPath(baseNIFPath);
+    const auto createdNIFPathLP = ParallaxGenUtil::getPluginPathFromDataPath(createdNIFPath);
+
+    // check if s_lightPlacerJSONMap contains the baseNIFPath
+    auto it = s_lightPlacerJSONMap.find(baseNIFPathLP);
+    if (it == s_lightPlacerJSONMap.end()) {
+        // No light placer JSONs for this nif
+        return;
+    }
+
+    // Get the vector of LPJSON pointers and models
+    auto& lpJSONs = it->second;
+
+    // Loop through each LPJSON and update the models
+    for (const auto& [lpJsonPtr, models] : lpJSONs) {
+        // lock mutex for modifying json
+        const lock_guard<mutex> lock(lpJsonPtr->jsonMutex);
+
+        // Add to models if not already present (models is already a json array)
+        const auto createdNIFPathStr = ParallaxGenUtil::utf16toUTF8(createdNIFPathLP.wstring());
+        if (!ParallaxGenUtil::checkIfStringInJSONArray(*models, createdNIFPathStr)) {
+            models->push_back(createdNIFPathStr);
+            lpJsonPtr->changed = true; // mark as changed
+        }
+    }
+}
+
+void HandlerLightPlacerTracker::finalize()
+{
+    // get PGD object
+    static auto* const pgd = PGGlobals::getPGD();
+    static const auto generatedDir = pgd->getGeneratedPath();
+
+    // Loop through each LPJSON and save if changed
+    for (const auto& lpJsonPtr : s_lightPlacerJSONs) {
+        if (lpJsonPtr->changed) {
+            const auto outputPath = generatedDir / lpJsonPtr->jsonPath;
+            // Ensure the directory exists
+            if (!filesystem::exists(outputPath.parent_path())) {
+                filesystem::create_directories(outputPath.parent_path());
+            }
+
+            ParallaxGenUtil::saveJSON(outputPath, lpJsonPtr->jsonData, true);
+        }
+    }
+
+    // Clear the static members
+    s_lightPlacerJSONs.clear();
+    s_lightPlacerJSONMap.clear();
+}

--- a/PGLib/src/handlers/HandlerLightPlacerTracker.cpp
+++ b/PGLib/src/handlers/HandlerLightPlacerTracker.cpp
@@ -32,7 +32,7 @@ void HandlerLightPlacerTracker::init(const vector<filesystem::path>& lpJSONs)
         auto* const lpJsonPtr = s_lightPlacerJSONs.back().get();
 
         // loop through json to create nif map
-        for (const auto& block : s_lightPlacerJSONs.back()->jsonData.items()) {
+        for (const auto& block : lpJsonPtr->jsonData.items()) {
             if (!block.value().is_object() || !block.value().contains("models")) {
                 continue; // skip if not a valid light placer block
             }

--- a/PGLib/src/util/ParallaxGenUtil.cpp
+++ b/PGLib/src/util/ParallaxGenUtil.cpp
@@ -227,4 +227,23 @@ auto checkIfStringInJSONArray(const nlohmann::json& json, const string& str) -> 
     return false;
 }
 
+auto getPluginPathFromDataPath(const filesystem::path& dataPath) -> filesystem::path
+{
+    static const string meshesPrefix = "meshes\\";
+    static const string texturesPrefix = "textures\\";
+
+    // Remove "meshes" from from the first part of both paths
+    auto dataPathWStr = dataPath.wstring();
+    if (boost::istarts_with(dataPathWStr, meshesPrefix)) {
+        dataPathWStr.erase(0, meshesPrefix.size()); // Remove "meshes\\"
+    } else if (boost::istarts_with(dataPathWStr, texturesPrefix)) {
+        dataPathWStr.erase(0, texturesPrefix.size()); // Remove "textures\\"
+    } else {
+        // If it doesn't start with meshes or textures, return the original path
+        return dataPath;
+    }
+
+    // Convert to filesystem::path
+    return dataPathWStr;
+}
 } // namespace ParallaxGenUtil

--- a/PGLib/src/util/ParallaxGenUtil.cpp
+++ b/PGLib/src/util/ParallaxGenUtil.cpp
@@ -229,21 +229,31 @@ auto checkIfStringInJSONArray(const nlohmann::json& json, const string& str) -> 
 
 auto getPluginPathFromDataPath(const filesystem::path& dataPath) -> filesystem::path
 {
-    static const string meshesPrefix = "meshes\\";
-    static const string texturesPrefix = "textures\\";
+    static const std::filesystem::path meshesPrefix = "meshes";
+    static const std::filesystem::path texturesPrefix = "textures";
 
-    // Remove "meshes" from from the first part of both paths
-    auto dataPathWStr = dataPath.wstring();
-    if (boost::istarts_with(dataPathWStr, meshesPrefix)) {
-        dataPathWStr.erase(0, meshesPrefix.size()); // Remove "meshes\\"
-    } else if (boost::istarts_with(dataPathWStr, texturesPrefix)) {
-        dataPathWStr.erase(0, texturesPrefix.size()); // Remove "textures\\"
-    } else {
-        // If it doesn't start with meshes or textures, return the original path
-        return dataPath;
+    auto relativePath = dataPath;
+
+    // Check if the first component is "meshes" or "textures"
+    if (!dataPath.empty()) {
+        auto iter = dataPath.begin();
+        if (*iter == meshesPrefix) {
+            // Erase the first component
+            relativePath = std::filesystem::path {};
+            for (++iter; iter != dataPath.end(); ++iter) {
+                relativePath /= *iter;
+            }
+        } else if (*iter == texturesPrefix) {
+            relativePath = std::filesystem::path {};
+            for (++iter; iter != dataPath.end(); ++iter) {
+                relativePath /= *iter;
+            }
+        } else {
+            return dataPath;
+        }
     }
 
-    // Convert to filesystem::path
-    return dataPathWStr;
+    return relativePath;
 }
+
 } // namespace ParallaxGenUtil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Light placer JSON files are now automatically updated when duplicate NIF files are generated, ensuring accurate tracking and integration of new models.
  * Support for recognizing and managing "lightplacer" JSON configuration files has been added.

* **Bug Fixes**
  * Improved handling of duplicate NIF generation to prevent inconsistencies in light placer data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->