### PR TITLE
fix: randomness around order of shape patching and alternate texture tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed shape deleting during patching messing up 3d indices in plugins
 - Fixed deleting shape when trigger is in plugins rather than meshes
+- Fixed randomness around order of patching shapes
 
 ## [1.1.3] - 2026-06-16
 

--- a/PGLib/include/pgutil/PGMeshPermutationTracker.hpp
+++ b/PGLib/include/pgutil/PGMeshPermutationTracker.hpp
@@ -189,7 +189,11 @@ private:
                             const nifly::NifFile& meshB,
                             const std::unordered_set<unsigned int>& enforceCheckShapeTXSTA,
                             bool compareAllTXST = false,
-                            bool checkOnlyWeighted = false) -> bool;
+                            bool checkOnlyWeighted = false,
+                            const std::unordered_map<int,
+                                                     int>* meshAInverseIdxCorrectionsPatching = nullptr,
+                            const std::unordered_map<int,
+                                                     int>* meshBInverseIdxCorrectionsPatching = nullptr) -> bool;
 
     /**
      * @brief Compares two BSTriShape blocks for geometric equivalence.
@@ -279,6 +283,12 @@ private:
                                                                               int>;
 
     static auto get3dIndicesSet(const nifly::NifFile* nif) -> std::unordered_set<int>;
+
+    static auto buildInverseIdxCorrections(const std::unordered_map<nifly::NiObject*,
+                                                                    int>& current3DIndices,
+                                           const std::unordered_map<nifly::NiObject*,
+                                                                    int>& original3DIndices) -> std::unordered_map<int,
+                                                                                                                   int>;
 
     /**
      * @brief Resolves the path of the corresponding weighted variant (_0/_1) for a given NIF.

--- a/PGLib/include/pgutil/PGMeshPermutationTracker.hpp
+++ b/PGLib/include/pgutil/PGMeshPermutationTracker.hpp
@@ -191,9 +191,7 @@ private:
                             bool compareAllTXST = false,
                             bool checkOnlyWeighted = false,
                             const std::unordered_map<int,
-                                                     int>* meshAInverseIdxCorrectionsPatching = nullptr,
-                            const std::unordered_map<int,
-                                                     int>* meshBInverseIdxCorrectionsPatching = nullptr) -> bool;
+                                                     int>* meshAInverseIdxCorrectionsPatching = nullptr) -> bool;
 
     /**
      * @brief Compares two BSTriShape blocks for geometric equivalence.

--- a/PGLib/include/pgutil/PGNIFUtil.hpp
+++ b/PGLib/include/pgutil/PGNIFUtil.hpp
@@ -193,8 +193,8 @@ auto getSearchPrefixes(nifly::NifFile const& nif,
 auto getSearchPrefixes(const PGTypes::TextureSet& oldSlots,
                        const bool& findBaseSlots = true) -> PGTypes::TextureSet;
 
-auto getShapesWithBlockIDs(const nifly::NifFile* nif) -> std::vector<std::pair<nifly::NiShape*,
-                                                                               int>>;
+auto getShapesWith3DIdx(const nifly::NifFile* nif) -> std::vector<std::pair<nifly::NiShape*,
+                                                                            int>>;
 
 auto isPatchableShape(nifly::NifFile& nif,
                       nifly::NiShape& nifShape) -> bool;

--- a/PGLib/include/pgutil/PGNIFUtil.hpp
+++ b/PGLib/include/pgutil/PGNIFUtil.hpp
@@ -13,8 +13,8 @@
 #include <map>
 #include <string>
 #include <tuple>
-#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace PGNIFUtil {
@@ -193,8 +193,8 @@ auto getSearchPrefixes(nifly::NifFile const& nif,
 auto getSearchPrefixes(const PGTypes::TextureSet& oldSlots,
                        const bool& findBaseSlots = true) -> PGTypes::TextureSet;
 
-auto getShapesWithBlockIDs(const nifly::NifFile* nif) -> std::unordered_map<nifly::NiShape*,
-                                                                            int>;
+auto getShapesWithBlockIDs(const nifly::NifFile* nif) -> std::vector<std::pair<nifly::NiShape*,
+                                                                               int>>;
 
 auto isPatchableShape(nifly::NifFile& nif,
                       nifly::NiShape& nifShape) -> bool;

--- a/PGLib/src/PGDirectory.cpp
+++ b/PGLib/src/PGDirectory.cpp
@@ -352,7 +352,7 @@ auto PGDirectory::mapTexturesFromNIF(const filesystem::path& nifPath,
     }
 
     // Loop through each shape
-    const auto shapes = PGNIFUtil::getShapesWithBlockIDs(nif.get());
+    const auto shapes = PGNIFUtil::getShapesWith3DIdx(nif.get());
     // clear shapes in cache
     std::vector<std::pair<int, PGTypes::TextureSet>> textureSets;
     for (const auto& [shape, oldindex3d] : shapes) {

--- a/PGLib/src/PGPatcher.cpp
+++ b/PGLib/src/PGPatcher.cpp
@@ -520,7 +520,7 @@ auto PGPatcher::processNIF(const std::filesystem::path& nifPath,
             ptrAltTex = &alternateTextures.at(oldIndex3D);
         } else {
             // we want to include any texture sets that do not have alternate textures defined to be compared
-            nonAltTexShapes.insert(shapeBlockID);
+            nonAltTexShapes.insert(oldIndex3D);
         }
         if (!processNIFShape(nifPath, nif, nifShape, patcherObjects, singlepassMATO, modelRecordType, ptrAltTex)) {
             return false;

--- a/PGLib/src/PGPatcher.cpp
+++ b/PGLib/src/PGPatcher.cpp
@@ -496,7 +496,7 @@ auto PGPatcher::processNIF(const std::filesystem::path& nifPath,
     const auto patcherObjects = createNIFPatcherObjects(nifPath, nif);
 
     // Get shapes and index 3ds (this is in the order as they would show up as 3d indices in plugins)
-    const auto shapes = PGNIFUtil::getShapesWithBlockIDs(nif);
+    const auto shapes = PGNIFUtil::getShapesWith3DIdx(nif);
 
     for (const auto& [nifShape, oldIndex3D] : shapes) {
         const auto shapeBlockID = nif->GetBlockID(nifShape);

--- a/PGLib/src/pgutil/PGMeshPermutationTracker.cpp
+++ b/PGLib/src/pgutil/PGMeshPermutationTracker.cpp
@@ -112,9 +112,21 @@ auto PGMeshPermutationTracker::commitMesh(const FormKey& formKey,
     // Add to processed form keys
     m_processedFormKeys.insert(formKey);
 
+    // Build current->original 3D index map for the staged mesh so comparisons remain stable if
+    // patchers deleted shapes and shifted current indices.
+    const auto stagedCurrent3DIndices = get3dIndices(m_stagedMeshPtr);
+    const auto stagedInverseIdxCorrectionsPatching
+        = buildInverseIdxCorrections(stagedCurrent3DIndices, m_stagedMeshOriginal3DIdx);
+
     // Check if staged mesh is different from all existing output meshes
     for (auto& outputMesh : m_outputMeshes) {
-        if (compareMesh(m_stagedMesh, outputMesh.second, nonAltTexShapes)) {
+        if (compareMesh(m_stagedMesh,
+                        outputMesh.second,
+                        nonAltTexShapes,
+                        false,
+                        false,
+                        &stagedInverseIdxCorrectionsPatching,
+                        &outputMesh.first.inverseIdxCorrectionsPatching)) {
             // Mesh is identical to an existing output mesh, do not add
             outputMesh.first.altTexResults.emplace_back(formKey, altTexResults);
             // Clear staged mesh
@@ -142,17 +154,6 @@ auto PGMeshPermutationTracker::commitMesh(const FormKey& formKey,
         processWeightVariant();
     }
 
-    // Find index corrections for the staged mesh
-    const auto new3dIndices = get3dIndices(m_stagedMeshPtr);
-    unordered_map<int, int> inverseIdxCorrectionsPatching;
-    for (const auto& [nifObject, oldIndex3D] : m_stagedMeshOriginal3DIdx) {
-        if (new3dIndices.contains(nifObject)) {
-            // exists after patching, set new index 3d
-            const auto newIndex3D = new3dIndices.at(nifObject);
-            inverseIdxCorrectionsPatching[newIndex3D] = oldIndex3D;
-        }
-    }
-
     // Add new mesh
     nifly::NifFile newMesh;
     newMesh.CopyFrom(*m_stagedMeshPtr);
@@ -160,7 +161,7 @@ auto PGMeshPermutationTracker::commitMesh(const FormKey& formKey,
     const MeshResult meshResult = {.meshPath = {},
                                    .altTexResults = {{formKey, altTexResults}},
                                    .idxCorrections = {},
-                                   .inverseIdxCorrectionsPatching = inverseIdxCorrectionsPatching};
+                                   .inverseIdxCorrectionsPatching = stagedInverseIdxCorrectionsPatching};
 
     m_outputMeshes.emplace_back(meshResult, newMesh);
 
@@ -334,8 +335,14 @@ auto PGMeshPermutationTracker::compareMesh(const nifly::NifFile& meshA,
                                            const nifly::NifFile& meshB,
                                            const std::unordered_set<unsigned int>& enforceCheckShapeTXSTA,
                                            bool compareAllTXST,
-                                           bool checkOnlyWeighted) -> bool
+                                           bool checkOnlyWeighted,
+                                           const std::unordered_map<int,
+                                                                    int>* meshAInverseIdxCorrectionsPatching,
+                                           const std::unordered_map<int,
+                                                                    int>* meshBInverseIdxCorrectionsPatching) -> bool
 {
+    (void)meshBInverseIdxCorrectionsPatching;
+
     // This should be compared before sorting blocks (sorting blocks should happen last)
     const auto blocksA = getComparableBlocks(&meshA);
     const auto blocksB = getComparableBlocks(&meshB);
@@ -510,9 +517,17 @@ auto PGMeshPermutationTracker::compareMesh(const nifly::NifFile& meshA,
                 return false;
             }
 
-            // get txst block id
-            const auto shapeBlockIdA = meshA.GetBlockID(shapeA);
-            const bool enforceTxstCheck = enforceCheckShapeTXSTA.contains(shapeBlockIdA);
+            // Resolve the original 3D index (before patch-time deletions/reordering) for stable
+            // alternate-texture enforcement.
+            auto enforceIdxA = static_cast<unsigned int>(i);
+            if (meshAInverseIdxCorrectionsPatching != nullptr) {
+                const auto foundA = meshAInverseIdxCorrectionsPatching->find(static_cast<int>(i));
+                if (foundA != meshAInverseIdxCorrectionsPatching->end() && foundA->second >= 0) {
+                    enforceIdxA = static_cast<unsigned int>(foundA->second);
+                }
+            }
+
+            const bool enforceTxstCheck = enforceCheckShapeTXSTA.contains(enforceIdxA);
             if (!enforceTxstCheck && !compareAllTXST) {
                 continue;
             }
@@ -786,6 +801,26 @@ auto PGMeshPermutationTracker::get3dIndicesSet(const nifly::NifFile* nif) -> uno
     }
 
     return blocks;
+}
+
+auto PGMeshPermutationTracker::buildInverseIdxCorrections(const std::unordered_map<nifly::NiObject*,
+                                                                                   int>& current3DIndices,
+                                                          const std::unordered_map<nifly::NiObject*,
+                                                                                   int>& original3DIndices)
+    -> std::unordered_map<int,
+                          int>
+{
+    unordered_map<int, int> inverseIdxCorrections;
+    for (const auto& [nifObject, oldIndex3D] : original3DIndices) {
+        if (!current3DIndices.contains(nifObject)) {
+            continue;
+        }
+
+        const auto newIndex3D = current3DIndices.at(nifObject);
+        inverseIdxCorrections[newIndex3D] = oldIndex3D;
+    }
+
+    return inverseIdxCorrections;
 }
 
 auto PGMeshPermutationTracker::getOtherWeightVariant(const std::filesystem::path& nifPath) -> std::filesystem::path

--- a/PGLib/src/pgutil/PGMeshPermutationTracker.cpp
+++ b/PGLib/src/pgutil/PGMeshPermutationTracker.cpp
@@ -120,13 +120,8 @@ auto PGMeshPermutationTracker::commitMesh(const FormKey& formKey,
 
     // Check if staged mesh is different from all existing output meshes
     for (auto& outputMesh : m_outputMeshes) {
-        if (compareMesh(m_stagedMesh,
-                        outputMesh.second,
-                        nonAltTexShapes,
-                        false,
-                        false,
-                        &stagedInverseIdxCorrectionsPatching,
-                        &outputMesh.first.inverseIdxCorrectionsPatching)) {
+        if (compareMesh(
+                m_stagedMesh, outputMesh.second, nonAltTexShapes, false, false, &stagedInverseIdxCorrectionsPatching)) {
             // Mesh is identical to an existing output mesh, do not add
             outputMesh.first.altTexResults.emplace_back(formKey, altTexResults);
             // Clear staged mesh
@@ -337,12 +332,8 @@ auto PGMeshPermutationTracker::compareMesh(const nifly::NifFile& meshA,
                                            bool compareAllTXST,
                                            bool checkOnlyWeighted,
                                            const std::unordered_map<int,
-                                                                    int>* meshAInverseIdxCorrectionsPatching,
-                                           const std::unordered_map<int,
-                                                                    int>* meshBInverseIdxCorrectionsPatching) -> bool
+                                                                    int>* meshAInverseIdxCorrectionsPatching) -> bool
 {
-    (void)meshBInverseIdxCorrectionsPatching;
-
     // This should be compared before sorting blocks (sorting blocks should happen last)
     const auto blocksA = getComparableBlocks(&meshA);
     const auto blocksB = getComparableBlocks(&meshB);

--- a/PGLib/src/pgutil/PGNIFUtil.cpp
+++ b/PGLib/src/pgutil/PGNIFUtil.cpp
@@ -31,6 +31,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 #include <windows.h>
 
@@ -513,8 +514,8 @@ auto PGNIFUtil::getSearchPrefixes(const PGTypes::TextureSet& oldSlots,
     return outSlots;
 }
 
-auto PGNIFUtil::getShapesWithBlockIDs(const nifly::NifFile* nif) -> unordered_map<nifly::NiShape*,
-                                                                                  int>
+auto PGNIFUtil::getShapesWithBlockIDs(const nifly::NifFile* nif) -> vector<pair<nifly::NiShape*,
+                                                                                int>>
 {
     if (nif == nullptr) {
         throw runtime_error("NIF is null");
@@ -522,12 +523,12 @@ auto PGNIFUtil::getShapesWithBlockIDs(const nifly::NifFile* nif) -> unordered_ma
 
     vector<NiObject*> tree;
     nif->GetTree(tree);
-    unordered_map<NiShape*, int> shapes;
+    vector<pair<NiShape*, int>> shapes;
     int oldIndex3D = 0;
     for (auto& obj : tree) {
         auto* const curShape = dynamic_cast<NiShape*>(obj);
         if (curShape != nullptr) {
-            shapes[curShape] = oldIndex3D++;
+            shapes.emplace_back(curShape, oldIndex3D++);
             continue;
         }
 

--- a/PGLib/src/pgutil/PGNIFUtil.cpp
+++ b/PGLib/src/pgutil/PGNIFUtil.cpp
@@ -514,8 +514,8 @@ auto PGNIFUtil::getSearchPrefixes(const PGTypes::TextureSet& oldSlots,
     return outSlots;
 }
 
-auto PGNIFUtil::getShapesWithBlockIDs(const nifly::NifFile* nif) -> vector<pair<nifly::NiShape*,
-                                                                                int>>
+auto PGNIFUtil::getShapesWith3DIdx(const nifly::NifFile* nif) -> vector<pair<nifly::NiShape*,
+                                                                             int>>
 {
     if (nif == nullptr) {
         throw runtime_error("NIF is null");


### PR DESCRIPTION
Also makes alternate texture comparisons more stable by using index3D instead of blockid - verify no issues with logic there, especially when a shape is deleted