### PR TITLE
fix: prevent TaskPoolRunner hang when a task throws under multithreading

### DIFF
--- a/PGLib/src/util/TaskPoolRunner.cpp
+++ b/PGLib/src/util/TaskPoolRunner.cpp
@@ -91,9 +91,15 @@ void TaskPoolRunner::runTasks()
             break;
         }
 
-        // If exception stop thread pool and throw
+        // If exception stop thread pool and throw. stop() only prevents NOT-YET-STARTED tasks from
+        // running -- it does not (and cannot) retroactively mark them as completed, so
+        // m_completedTasks can never reach m_tasks.size() once even one task is abandoned this way.
+        // Without the break below, any exception thrown anywhere in a multithreaded run turns a
+        // real, reportable error into a silent, permanent hang instead: the caller waiting on this
+        // function never gets a chance to run, since the loop never returns.
         if (ExceptionHandler::hasException()) {
             m_threadPool.stop();
+            break;
         }
 
         // Sleep in between loops


### PR DESCRIPTION
## Summary
When a task throws an exception while multithreading is enabled, `TaskPoolRunner::runTasks()` calls `m_threadPool.stop()` but remains blocked waiting for all task completions. Because `stop()` only cancels unstarted tasks in the queue and cannot retroactively mark an already-aborted worker task as complete, the completion counter never reaches the target. As a result, any unhandled exception during a multithreaded run (e.g. in `patchMeshes()` or `patchTextures()`) results in a permanent hang rather than failing fast with a clean error.

## Root Cause & Discovery
During a build that hung indefinitely, attaching a debugger revealed the main thread blocked in the task-completion wait loop inside `runTasks()`, even after an exception (a local filesystem error) was thrown and caught.

## Fix
Break out of the task-completion wait loop immediately after invoking `m_threadPool.stop()`, ensuring aborted or abandoned worker tasks do not indefinitely block the main thread.

## Testing
- **Reproduction:** Triggered an intentional exception during multithreaded execution; verified the process exits immediately with a clean, reported error instead of hanging.
- **Regression Testing:** Executed a full, successful patch run to verify standard multithreaded task scheduling and completion tracking remain unaffected.