### PR TITLE
fix: prevent TaskPoolRunner hang when a task throws under multithreading

### DIFF
--- a/PGLib/src/util/TaskPoolRunner.cpp
+++ b/PGLib/src/util/TaskPoolRunner.cpp
@@ -94,6 +94,8 @@ void TaskPoolRunner::runTasks()
         // If exception stop thread pool and throw
         if (ExceptionHandler::hasException()) {
             m_threadPool.stop();
+            m_threadPool.join();
+            break;
         }
 
         // Sleep in between loops


### PR DESCRIPTION
Supersedes #731, closed for inactivity — same fix, now also addressing the review feedback that
was never responded to before it closed. Rebased onto current `main`.

**Summary**
When a task throws an exception while multithreading is enabled, `TaskPoolRunner::runTasks()` calls `m_threadPool.stop()` but remains blocked waiting for all task completions. Because `stop()` only cancels unstarted tasks in the queue and cannot retroactively mark an already-aborted worker task as complete, the completion counter never reaches the target. As a result, any unhandled exception during a multithreaded run (e.g. in `patchMeshes()` or `patchTextures()`) results in a permanent hang rather than failing fast with a clean error.

**Root Cause & Discovery**
During a build that hung indefinitely, attaching a debugger revealed the main thread blocked in the task-completion wait loop inside `runTasks()`, even after an exception (a local filesystem error) was thrown and caught.

**Fix**
Break out of the task-completion wait loop immediately after invoking `m_threadPool.stop()`, then call `m_threadPool.join()` before returning. `stop()` alone is not sufficient: it is non-blocking and only prevents *not-yet-started* tasks from running, so a worker task already mid-execution when `stop()` is called can still be running when `runTasks()` returns — and since each task's lambda captures `this`, a caller destroying the `TaskPoolRunner` shortly after return could hit a genuine use-after-free (flagged in review on the original submission). `join()` blocks until every already-started task actually finishes; since `stop()` already guarantees no *new* task is dispatched, this returns promptly rather than waiting out the full original task list.

**Testing**
- **Reproduction:** Triggered an intentional exception during multithreaded execution; verified the process exits immediately with a clean, reported error instead of hanging.
- **Regression Testing:** Executed a full, successful patch run to verify standard multithreaded task scheduling and completion tracking remain unaffected.
- **Review feedback:** The `join()` addition directly addresses the use-after-free concern raised on the original submission; it wasn't separately reproduced as a live race, but follows `boost::asio::thread_pool`'s own documented `stop()`+`join()` contract for a synchronous, safe halt.
