### PR TITLE
fix: make --no-multithreading flag properly disable multithreading

### DIFF
--- a/PGTools/src/main.cpp
+++ b/PGTools/src/main.cpp
@@ -280,7 +280,7 @@ void addArguments(CLI::App& app,
                  args.verbosity,
                  "Verbosity level -v for DEBUG data or -vv for TRACE data "
                  "(warning: TRACE data is very verbose)");
-    app.add_flag("--no-multithreading", args.multithreading, "Disable multithreading");
+    app.add_flag("--no-multithreading{false}", args.multithreading, "Disable multithreading");
     app.add_flag("--shortcut",
                  args.shortcut,
                  "Keep pgtools running at the end (useful if you are running not in a terminal directly)");


### PR DESCRIPTION
Supersedes #732, closed for inactivity — the requested change (dropping the explanatory comment)
is applied. Rebased onto current `main`.

**Summary**
The `--no-multithreading` flag has never actually disabled multithreading. CLI11's `add_flag()` on a plain bool just assigns `true` whenever the flag is passed — it doesn't infer inverted logic from a `--no-` prefix. Since `args.multithreading` already defaults to `true`, passing `--no-multithreading` was a no-op the entire time this flag has existed.

**Root Cause & Discovery**
Found while trying to force single-threaded execution to make a bug easier to debug. Despite passing `--no-multithreading`, worker threads were still spawned and tasks kept running across the thread pool.

**Fix**
Use CLI11's own `{false}` value syntax on the flag binding, so passing `--no-multithreading` explicitly sets `args.multithreading` to `false`.

**Testing**
- **Flag verification:** Ran a patch job with `--no-multithreading` and confirmed via debugger stack trace and run time that tasks now execute synchronously on the main thread.
- **Regression:** Ran a standard job without the flag to confirm default multithreaded execution is still enabled and unaffected.
