### PR TITLE
fix: correct dynamic cubemap asset filename

### DIFF
--- a/PGTools/src/main.cpp
+++ b/PGTools/src/main.cpp
@@ -258,7 +258,7 @@ void mainRunner(PGToolsCLIArgs& args)
             const filesystem::path outputCubemapPath = args.Patch.output / dynCubeMapPath.parent_path();
             filesystem::create_directories(outputCubemapPath);
 
-            const filesystem::path assetPath = filesystem::path(exePath) / "assets/dynamic1pxcubemap_black_ENB.dds";
+            const filesystem::path assetPath = filesystem::path(exePath) / "assets/dynamic1pxcubemap_black.dds";
             const filesystem::path outputPath = filesystem::path(args.Patch.output) / dynCubeMapPath;
 
             // Move File


### PR DESCRIPTION
**Summary**
When running `pgtools patch` with the ComplexMaterial patcher enabled and dynamic cubemaps active (the default when `disable_dyncubemap` is false), execution crashes with an unhandled `std::filesystem::copy_file` exception (`The system cannot find the file specified`) during the "Installing default dynamic cubemap file" step.

**Root Cause & Discovery**
`PGTools/src/main.cpp` attempts to locate and copy `assets/dynamic1pxcubemap_black_ENB.dds` relative to the executable path. This file does not exist in the repository or build distribution.

The actual bundled asset distributed under `PGPatcher/assets/` is `dynamic1pxcubemap_black.dds` (without the `_ENB` suffix). The GUI implementation in `PGPatcher/src/main.cpp` already references the correct filename; the CLI runner in `PGTools` had an errant `_ENB` suffix introduced when the step was originally added.

**Fix**
Updated the asset filename string in `PGTools/src/main.cpp` from `dynamic1pxcubemap_black_ENB.dds` to `dynamic1pxcubemap_black.dds` to match the actual bundled asset and the GUI's existing implementation.

**Testing**
- **Verification by inspection & parity:** Confirmed that the updated filename matches the asset present on disk in `PGPatcher/assets/` as well as the exact string literal already used successfully by `PGPatcher/src/main.cpp`.
- **Note on end-to-end run:** A clean rebuild of `pgtools.exe` was blocked by an unrelated local build dependency issue, so an end-to-end execution test was not re-run. Because this is a single string literal correction bringing the CLI into exact parity with the working GUI code, risk is negligible.
